### PR TITLE
fixed unintented break of loop and input checking for duplicate positions

### DIFF
--- a/CanSNPer2/modules/DatabaseConnection.py
+++ b/CanSNPer2/modules/DatabaseConnection.py
@@ -354,6 +354,12 @@ class XMFAFunctions(DatabaseConnection):
 		SNPs = {}
 		res = self.query(snp_string, (reference,),getres=True)
 		for strain, pos,tbase,rbase,SNP in res.fetchall():
+			# check if this position was already added and if so throw an error (cansnper does not save SNPs by their ID but rather by their position in each reference)
+			if pos in SNPs:
+				logger.error("Error: there was a duplicate CanSNP in your CanSNPer database at position "+str(pos)+" in reference "+reference)
+				logger.error("Please check your database input files")
+				raise Exception("Multiple SNPs with same position")
+			#/
 			SNPs[pos] = tuple([pos,rbase, tbase,SNP])
 		return SNPs
 

--- a/CanSNPer2/modules/ParseXMFA.py
+++ b/CanSNPer2/modules/ParseXMFA.py
@@ -133,8 +133,12 @@ class ParseXMFA(object):
 			targetHead = self.parse_head(targetSeq.pop(0))	## parse target sequence header
 			'''Parse aligned sequence pair '''
 			while int(self.current_snp) < int(refHead["start"]): ## Current SNP not aligned
-				if not self._next_pos():
+				# Keep iterating new canSNP-positions until the end of current alignment or until there are no more canSNPs to check
+				self._next_pos() # iterate snp position
+				if self.current_snp > refHead["end"] or len(self.snp_positions) == 0: # if the new snp position is beyond alignment range, then break. Also break if we run out of snp positions to check
 					break
+				#/
+
 			if refHead["start"] < self.current_snp and refHead["end"] > self.current_snp:
 				'''Check if current snp is within this mapped region else skip'''
 				ref = "".join(refSeq)				 ## Make reference sequence one string


### PR DESCRIPTION
I made a database with added custom SNPs that were not called as expected. I identified the bug to be due to a presumably unintented break in the loop that iterates SNPs in each alignment.